### PR TITLE
feat: better error response when trying to retrieve a game

### DIFF
--- a/server/src/gamesRouter.mjs
+++ b/server/src/gamesRouter.mjs
@@ -17,9 +17,9 @@ router.get("/:id", async (request, response) => {
     const { games } = await bga("search", {
       searchParams: { ids: request.params.id },
     });
-    response.json(games[0]).end();
-  } catch (error) {
-    response.json({ error: "game not found" });
+    response.json(games[0]);
+  } catch ({ response: { statusCode, statusMessage } }) {
+    response.status(statusCode).json({ error: statusMessage });
   }
 });
 


### PR DESCRIPTION
Return the actual status from the upstream API.

The upstream API is very slow to respond back with a 404, it takes about 25 seconds for me:

<https://api.boardgameatlas.com/api/search?ids=abc&client_id=[your_client_id_here]>